### PR TITLE
Security: bump pypdf to >=6,<7 to address CVE-2025-55197; add README …

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,15 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - Uses PyMuPDF for PDF processing and rendering
 - Leverages Poppler tools for enhanced PDF analysis
 - Ghostscript integration for specialized compression scenarios
+
+## Security update
+
+On 2025-08-21, dependencies were updated to address a security advisory:
+
+- Bumped `pypdf` to `>=6.0.0,<7` per Dependabot alert (CVE-2025-55197). This project uses pypdf for PDF analysis (reading, text extraction, and metadata probing) and is compatible with 6.x APIs.
+
+Action for users: update your environment
+
+```bash
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt6>=6.5,<7
-pypdf>=4.0.0,<6
+pypdf>=6.0.0,<7
 pymupdf>=1.23.8,<2
 pdf2image>=1.17.0,<2
 Pillow>=10.0.0,<12


### PR DESCRIPTION
…note